### PR TITLE
:memo: Document special-file data loss on archive save

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ Mount archive:
 $ pnafs mount archive.pna /mnt/pnafs/
 ```
 
+#### Special files are not persisted
+
+Special files — named pipes (fifo), sockets, and device nodes — are
+supported only in memory while a writable archive is mounted. The PNA
+format has no on-disk representation for them, so they are silently
+dropped (with a warning) when the archive is saved. Any such node you
+create while mounted will disappear from the archive once it is written
+back; this is a data-loss risk, so avoid relying on special files inside
+a PNA-FS mount.
+
+```bash
+$ mkfifo /mnt/pnafs/pipe   # exists during the mount
+$ # ...after unmount and reload, /mnt/pnafs/pipe is gone
+```
+
 ### Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ $ pnafs mount archive.pna /mnt/pnafs/
 
 Special files — named pipes (fifo), sockets, and device nodes — are
 supported only in memory while a writable archive is mounted. The PNA
-format has no on-disk representation for them, so they are silently
-dropped (with a warning) when the archive is saved. Any such node you
+format has no on-disk representation for them, so they are dropped
+(with a warning) when the archive is saved. Any such node you
 create while mounted will disappear from the archive once it is written
 back; this is a data-loss risk, so avoid relying on special files inside
 a PNA-FS mount.


### PR DESCRIPTION
## Summary
- Add a Troubleshooting note to `README.md` explaining that special files
  (fifo / socket / device nodes) live only in memory during a writable
  mount and are silently dropped when the archive is saved.
- Includes a short `mkfifo` example illustrating the data-loss risk.
- Documentation only; no code or behavior changes.

Closes #437

## Test plan
- [x] `cargo fmt --check` passes (docs-only change)
- [x] README renders correctly; new section follows existing tone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation explaining that special files (FIFOs, sockets, and device nodes) are only supported in memory when a writable archive is mounted. These files are dropped on save with a warning, and special-file nodes created during mount disappear after unmount or reload. Includes example usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Portable-Network-Archive/fs/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->