### PR TITLE
:white_check_mark: Add clap parser tests for mount subcommand flags

### DIFF
--- a/src/command/mount.rs
+++ b/src/command/mount.rs
@@ -92,3 +92,67 @@ fn mount_archive(
     mount2(fs, mount_point, &config)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::WriteStrategy;
+    use crate::cli::{Cli, SubCommand};
+    use clap::Parser;
+
+    fn parse_mount(args: &[&str]) -> Result<super::MountOptions, clap::Error> {
+        let argv = ["pnafs", "mount"]
+            .iter()
+            .copied()
+            .chain(args.iter().copied())
+            .chain(["archive.pna", "mnt"]);
+        let cli = Cli::try_parse_from(argv)?;
+        match cli.subcommand {
+            SubCommand::Mount(m) => Ok(m.mount_options),
+            _ => unreachable!("mount subcommand requested"),
+        }
+    }
+
+    #[test]
+    fn default_is_read_only() {
+        let opts = parse_mount(&[]).unwrap();
+        assert!(!opts.write);
+        assert!(opts.write_strategy == WriteStrategy::Lazy);
+    }
+
+    #[test]
+    fn write_enables_default_lazy_strategy() {
+        let opts = parse_mount(&["--write"]).unwrap();
+        assert!(opts.write);
+        assert!(opts.write_strategy == WriteStrategy::Lazy);
+    }
+
+    #[test]
+    fn write_strategy_immediate_with_write() {
+        let opts = parse_mount(&["--write", "--write-strategy", "immediate"]).unwrap();
+        assert!(opts.write);
+        assert!(opts.write_strategy == WriteStrategy::Immediate);
+    }
+
+    #[test]
+    fn write_strategy_immediate_requires_write() {
+        let err = match parse_mount(&["--write-strategy", "immediate"]) {
+            Err(e) => e,
+            Ok(_) => panic!("--write-strategy without --write should be a parse error"),
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn allow_root_parses() {
+        let opts = parse_mount(&["--allow-root"]).unwrap();
+        assert!(opts.allow_root);
+        assert!(!opts.allow_other);
+    }
+
+    #[test]
+    fn allow_other_parses() {
+        let opts = parse_mount(&["--allow-other"]).unwrap();
+        assert!(opts.allow_other);
+        assert!(!opts.allow_root);
+    }
+}

--- a/src/command/mount.rs
+++ b/src/command/mount.rs
@@ -108,7 +108,10 @@ mod tests {
         let cli = Cli::try_parse_from(argv)?;
         match cli.subcommand {
             SubCommand::Mount(m) => Ok(m.mount_options),
-            _ => unreachable!("mount subcommand requested"),
+            _ => unreachable!(
+                "argv is hard-coded with the \"mount\" subcommand, so clap cannot \
+                 parse any other variant here"
+            ),
         }
     }
 


### PR DESCRIPTION
## Summary
Adds CLI parsing tests for the `mount` subcommand flags, pinning the
current clap contract. Closes #434.

- `MountArgs` / `MountOptions` had no tests covering the `--write`,
  `--write-strategy`, `--allow-root`, `--allow-other` flag wiring, so a
  regression in that wiring would not be caught by `cargo test`.
- 6 tests drive the clap parser directly via `Cli::try_parse_from`
  (no FUSE, no mount), colocated in `src/command/mount.rs`:
  - read-only default (no `--write`) -> `write=false`, strategy `Lazy`
  - `--write` enables the default `Lazy` strategy
  - `--write --write-strategy immediate` -> `Immediate`
  - `--write-strategy immediate` without `--write` -> `MissingRequiredArgument` parse error
  - `--allow-root` / `--allow-other` parse as expected
- No CLI behavior changed; this only pins current behavior.

## Test plan
- [x] `cargo fmt --check` — passes
- [x] `cargo test --locked --release` — 182 passed; 0 failed (incl. the 6 new tests)
- [x] Diff introduces zero new clippy findings (`mount.rs` clean)

## Pre-existing clippy (not introduced here)
On the clean base (`09f66c7`) with local rust 1.94.0,
`cargo clippy --all-targets --all-features -- -D warnings` reports 12
errors, all in `src/roundtrip_proptest.rs` (e.g. `unnecessary_mut_passed`
on `archive_io::save`, redundant `as u64` casts, a complex-type lint).
These exist independently of this PR (verified via `git stash`) and are
out of scope for #434, so they are intentionally left unfixed here. Repo
CI runs clippy without `-D warnings` (SARIF-only, non-failing).