### PR TITLE
:white_check_mark: Add deterministic unlink-while-open (orphan) regression test

### DIFF
--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -3027,12 +3027,12 @@ mod tests {
         a.finalize().unwrap();
 
         let mut tree = crate::archive_io::load(&archive, None).unwrap();
-        let (_, node) = tree
-            .children(ROOT_INODE)
-            .unwrap()
-            .find(|(n, _)| n.to_str() == Some("doomed.txt"))
-            .unwrap();
-        let ino = node.attr.ino.0;
+        let ino = tree
+            .lookup_child(ROOT_INODE, OsStr::new("doomed.txt"))
+            .expect("doomed.txt must exist after load")
+            .attr
+            .ino
+            .0;
 
         // Open a handle, then unlink the only directory entry.
         tree.bump_open(ino).unwrap();

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -3000,6 +3000,81 @@ mod tests {
         assert!(tree.get(dst_ino).is_none());
     }
 
+    /// End-to-end regression for the unlink-while-open (orphan) lifecycle.
+    ///
+    /// Walks the full contract documented on `FsNode::open_count`:
+    /// create + write, open a handle, unlink the path, the path lookup
+    /// then fails (the FUSE `lookup` maps this `None` to `ENOENT`), the
+    /// still-open handle keeps reading the pre-unlink content, the final
+    /// release frees the orphan, and a save/reload no longer carries the
+    /// deleted file. Deterministic and seed-free: a fixed name and fixed
+    /// bytes, no `fsstress`, no randomness.
+    #[test]
+    fn unlink_while_open_orphan_lifecycle_round_trips_through_save() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let archive = dir.path().join("orphan.pna");
+
+        // Build an archive holding a single file with known content so
+        // the load path produces a real (non-test) FileTree to mutate.
+        let mut a = pna::Archive::write_header(std::fs::File::create(&archive).unwrap()).unwrap();
+        let mut b = pna::EntryBuilder::new_file(
+            pna::EntryName::from_lossy("doomed.txt"),
+            pna::WriteOptions::builder().build(),
+        )
+        .unwrap();
+        std::io::Write::write_all(&mut b, b"orphan-payload").unwrap();
+        a.add_entry(b.build().unwrap()).unwrap();
+        a.finalize().unwrap();
+
+        let mut tree = crate::archive_io::load(&archive, None).unwrap();
+        let (_, node) = tree
+            .children(ROOT_INODE)
+            .unwrap()
+            .find(|(n, _)| n.to_str() == Some("doomed.txt"))
+            .unwrap();
+        let ino = node.attr.ino.0;
+
+        // Open a handle, then unlink the only directory entry.
+        tree.bump_open(ino).unwrap();
+        tree.unlink(ROOT_INODE, OsStr::new("doomed.txt")).unwrap();
+
+        // Path lookup now fails — FUSE `lookup` turns this into ENOENT.
+        assert!(
+            tree.lookup_child(ROOT_INODE, OsStr::new("doomed.txt"))
+                .is_none(),
+            "unlinked path must no longer resolve"
+        );
+
+        // The held fd keeps the inode alive as an orphan and still reads
+        // the content written before the unlink.
+        let orphan = tree.get(ino).expect("orphan inode must survive unlink");
+        assert_eq!(orphan.attr.nlink, 0);
+        assert_eq!(orphan.open_count.load(Ordering::Relaxed), 1);
+        match &orphan.content {
+            FsContent::File(fd) => assert_eq!(fd.data(), b"orphan-payload"),
+            _ => panic!("expected file content on orphan"),
+        }
+
+        // Closing the last fd frees the orphan inode.
+        let was_last = tree.release_open(ino);
+        assert!(was_last, "release of the only fd on an orphan is the last");
+        tree.try_free_orphan(ino);
+        assert!(
+            tree.get(ino).is_none(),
+            "orphan must be freed after the final release"
+        );
+
+        // Save and reload: the deleted file must be absent from the archive.
+        crate::archive_io::save(&tree).unwrap();
+        let reloaded = crate::archive_io::load(&archive, None).unwrap();
+        assert!(
+            reloaded
+                .lookup_child(ROOT_INODE, OsStr::new("doomed.txt"))
+                .is_none(),
+            "deleted file must not reappear after save/reload"
+        );
+    }
+
     #[test]
     fn unlink_keeps_inode_when_other_links_exist() {
         let (mut tree, ino) = make_tree_with_file(b"shared");


### PR DESCRIPTION
Closes #436.

## Summary
- Adds one focused, **deterministic and seed-free** test in `src/file_tree.rs`: `unlink_while_open_orphan_lifecycle_round_trips_through_save`.
- Documents the orphan-inode contract (`nlink == 0 && open_count > 0`) end-to-end, independent of `fsstress` and with no random seeds (fixed file name + fixed bytes).

## Layer choice: FileTree unit/integration (no FUSE)
The orphan lifecycle is fully reachable at the `FileTree` API layer, so no mount-level script is needed:
- `bump_open` / `unlink` / `lookup_child` / `get` / `release_open` / `try_free_orphan` expose every state transition.
- The "lookup fails with ENOENT" contract maps cleanly: FUSE `lookup` (`src/filesystem.rs:82-86`) returns `ENOENT` exactly when `tree.lookup_child(...)` is `None`, which the test asserts directly.
- Uses the same real-tempfile-archive `load` / `save` pattern as the existing `setxattr_round_trips_through_save_and_load` test to validate the post-reload absence.

Scenario asserted (matches the issue exactly):
1. create file + write content, open a handle
2. unlink the path → `lookup_child` returns `None` (FUSE would map to `ENOENT`)
3. orphan inode survives: `nlink == 0`, `open_count == 1`, held fd still reads the pre-unlink content
4. final `release_open` + `try_free_orphan` frees the inode
5. after `save` + `load`, the deleted file is absent

## Test plan
- [x] `cargo fmt --check` — passes
- [x] `cargo test --locked --release` — 177/177 pass (incl. the new test)
- [x] New code introduces **zero** new clippy findings vs base

## Pre-existing clippy (not introduced here)
`cargo clippy --locked --all-targets --all-features -- -D warnings` reports 12 findings, but these are **pre-existing on a clean base** (verified via `git stash`: 12 at HEAD, 12 with this change) and are triggered by a newer local clippy (rust 1.94.0). They are unrelated to #436 and out of scope (a dedicated cleanup PR will address them). Repo CI clippy (`.github/workflows/rust-clippy.yml`) runs without `-D warnings` (SARIF report only) and does not red-fail on them. List:
- `save doesn't need a mutable reference` x9: `archive_io.rs:867,898,943,947`; `file_tree.rs:2653` (existing setxattr test); `roundtrip_proptest.rs:847,974,1169,1197`
- `casting integer literal to u64 is unnecessary` x2: `file_tree.rs:2686,2702` (existing test)
- `very complex type` x1: `roundtrip_proptest.rs:935`