### PR TITLE
:wrench: Correct upload-artifact pin version comments to v7.0.1

### DIFF
--- a/.github/workflows/proptest.yml
+++ b/.github/workflows/proptest.yml
@@ -60,7 +60,7 @@ jobs:
         # of the runner FS so it survives — committing it back into the
         # repo is what makes the case re-run on every future push.
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: proptest-regressions
           path: proptest-regressions/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         # committed back. Per-matrix entry name keeps the 8 parallel
         # runs from clobbering each other.
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: proptest-regressions-${{ matrix.os }}-${{ matrix.rust }}
           path: proptest-regressions/
@@ -160,7 +160,7 @@ jobs:
           ./scripts/tests/test_fsx.sh
       - name: Upload fsx artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fsx-artifacts
           path: ${{ github.workspace }}/fsx-artifacts


### PR DESCRIPTION
## Summary
Comment-only fix. PR #430 bumped `actions/upload-artifact` and pinned it
to SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`, which is upstream tag
**v7.0.1**. However the inline version comments on those pins were left
reading the stale `# v4.6.2`, making the pinned version misleading to
readers and to pin-audit tooling.

This corrects the trailing comments only — no SHA, no behavior change:

- `.github/workflows/test.yml` line 69: `# v4.6.2` -> `# v7.0.1`
- `.github/workflows/test.yml` line 163: `# v4.6.2` -> `# v7.0.1`
- `.github/workflows/proptest.yml` line 63: `# v4.6.2` -> `# v7.0.1`

The pinned SHA `043fb46…` is unchanged on all three lines. `release.yml`
is intentionally not touched (its `@v7.0.1` tag-vs-SHA pinning style is a
separate, out-of-scope item).

Follow-up to #430. Related: #438.

## Test plan
- [x] `grep -n "upload-artifact@043fb46"` on both workflows confirms all
      three now read `# v7.0.1`
- [x] No `# v4.6.2` remains anywhere under `.github/workflows/`
- [x] `git diff` shows exactly 3 changed lines, comment text only, SHA unchanged
- [x] No other files modified