### PR TITLE
:white_check_mark: Add rename / hardlink / fallocate ops to round-trip mutation proptest (#431 #432 #433)

### DIFF
--- a/src/roundtrip_proptest.rs
+++ b/src/roundtrip_proptest.rs
@@ -260,6 +260,17 @@ enum FsOp {
         dest_dir: proptest::sample::Index,
         dest_name: String,
     },
+    /// `fallocate(2)` against some existing File. `offset` / `length`
+    /// stay small so generated calls land inside or just past EOF;
+    /// `mode` is restricted to the three supported flavours. Targets
+    /// that are not regular files, or a zero length, return an errno
+    /// and are silently skipped.
+    Fallocate {
+        target: proptest::sample::Index,
+        offset: u64,
+        length: u64,
+        mode: FallocMode,
+    },
 }
 
 /// Which flavour of `rename(2)` an `FsOp::Rename` issues. Splitting
@@ -275,6 +286,37 @@ enum RenameMode {
     /// `RENAME_EXCHANGE`: atomically swap two existing entries;
     /// `ENOENT` (skipped) if the destination does not exist.
     Exchange,
+}
+
+/// The three `fallocate(2)` flavours `FileTree::fallocate` supports.
+/// Generating this closed set (instead of a raw `i32` mode) keeps the
+/// shrinker tight and never produces an unsupported combination that
+/// would just be skipped — except `PunchHole`, kept here precisely so
+/// the round-trip of a zeroed range is covered.
+#[derive(Debug, Clone, Copy)]
+enum FallocMode {
+    /// `mode == 0`: grow to `offset + length` with zero-fill and
+    /// update `attr.size`.
+    Grow,
+    /// `FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE` (0x03): zero out
+    /// `[offset, offset+length)` without changing size.
+    PunchHole,
+    /// `FALLOC_FL_ZERO_RANGE` (0x10): zero the range, growing if it
+    /// extends past EOF.
+    ZeroRange,
+}
+
+impl FallocMode {
+    fn flag(self) -> i32 {
+        const FALLOC_FL_KEEP_SIZE: i32 = 0x01;
+        const FALLOC_FL_PUNCH_HOLE: i32 = 0x02;
+        const FALLOC_FL_ZERO_RANGE: i32 = 0x10;
+        match self {
+            FallocMode::Grow => 0,
+            FallocMode::PunchHole => FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+            FallocMode::ZeroRange => FALLOC_FL_ZERO_RANGE,
+        }
+    }
 }
 
 fn arb_fs_op() -> impl Strategy<Value = FsOp> {
@@ -315,6 +357,18 @@ fn arb_fs_op() -> impl Strategy<Value = FsOp> {
                 dest_dir,
                 dest_name,
             }),
+        2 => (
+            any::<proptest::sample::Index>(),
+            0u64..=8192,
+            1u64..=8192,
+            arb_falloc_mode(),
+        )
+            .prop_map(|(target, offset, length, mode)| FsOp::Fallocate {
+                target,
+                offset,
+                length,
+                mode,
+            }),
     ]
 }
 
@@ -323,6 +377,14 @@ fn arb_rename_mode() -> impl Strategy<Value = RenameMode> {
         3 => Just(RenameMode::Plain),
         1 => Just(RenameMode::NoReplace),
         1 => Just(RenameMode::Exchange),
+    ]
+}
+
+fn arb_falloc_mode() -> impl Strategy<Value = FallocMode> {
+    prop_oneof![
+        2 => Just(FallocMode::Grow),
+        1 => Just(FallocMode::PunchHole),
+        2 => Just(FallocMode::ZeroRange),
     ]
 }
 
@@ -335,13 +397,18 @@ struct Expectations {
     /// be renamed / unlinked by a *later* op, so the assertion only
     /// checks pairs whose both ends still resolve after reload.
     placed_links: Vec<(String, String)>,
+    /// Paths an `FsOp::Fallocate` touched, deduplicated. The expected
+    /// post-reload bytes are read from the *final* in-memory tree
+    /// (after every op) by the caller, so a later op overwriting the
+    /// same file simply changes the expectation rather than racing.
+    fallocated: std::collections::BTreeSet<String>,
 }
 
 /// Apply `ops` to `tree`, silently skipping invalid ones. Returns the
-/// hardlinks created so the calling property can assert their
-/// round-trip; the generic invariants (directory nlink,
-/// size==content, idempotence) are still checked by the property
-/// regardless.
+/// hardlinks created and the files `fallocate` touched so the calling
+/// property can assert their round-trip; the generic invariants
+/// (directory nlink, size==content, idempotence) are still checked by
+/// the property regardless.
 fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
     let mut exp = Expectations::default();
     for op in ops {
@@ -548,6 +615,26 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
                     .is_ok()
                 {
                     exp.placed_links.push((source_path.clone(), dest_path));
+                }
+            }
+            FsOp::Fallocate {
+                target,
+                offset,
+                length,
+                mode,
+            } => {
+                if files.is_empty() {
+                    continue;
+                }
+                let path = files[target.index(files.len())].clone();
+                if let Some(ino) = tree.resolve_path(Path::new(&path)) {
+                    // EISDIR / EINVAL / ENOTSUP for non-file targets
+                    // or unsupported combos are silently skipped; the
+                    // generated `mode` is already restricted to the
+                    // three supported flavours.
+                    if tree.fallocate(ino, *offset, *length, mode.flag()).is_ok() {
+                        exp.fallocated.insert(path);
+                    }
                 }
             }
         }
@@ -1290,6 +1377,45 @@ fn assert_mutation_hardlinks_equivalent(
     Ok(())
 }
 
+/// SPEC: every file an `FsOp::Fallocate` touched round-trips its size
+/// and exact bytes through `save → load`. `expected` holds the final
+/// in-memory contents (after the whole op sequence) keyed by path; a
+/// path absent from the reloaded snapshot is tolerated (a later op
+/// renamed or unlinked it). Sparse/hole structure is intentionally
+/// *not* asserted — only the observable read-back bytes and size, per
+/// issue #433's note that on-disk sparseness need not survive
+/// identically.
+fn assert_fallocate_round_trips(
+    snap: &BTreeMap<String, ObservedNode>,
+    expected: &BTreeMap<String, Vec<u8>>,
+) -> Result<(), TestCaseError> {
+    for (path, want) in expected {
+        let Some(obs) = snap.get(path) else {
+            continue;
+        };
+        let Observed::File { content } = &obs.kind else {
+            return Err(TestCaseError::fail(format!(
+                "fallocate'd path {path} reloaded as a non-file"
+            )));
+        };
+        prop_assert_eq!(
+            content,
+            want,
+            "fallocate'd file {} bytes diverged across save→load",
+            path
+        );
+        prop_assert_eq!(
+            obs.size,
+            want.len() as u64,
+            "fallocate'd file {} attr.size {} mismatches content.len {}",
+            path,
+            obs.size,
+            want.len()
+        );
+    }
+    Ok(())
+}
+
 proptest! {
     // Plaintext properties: 64 cases keeps `cargo test` under a few
     // seconds locally. The scheduled CI job runs at
@@ -1381,6 +1507,24 @@ proptest! {
         build_and_save(&archive, &input).unwrap();
         let mut tree = archive_io::load(&archive, None).unwrap();
         let exp = apply_ops(&mut tree, &ops);
+
+        // Expected post-reload bytes for every fallocate'd file,
+        // read from the FINAL in-memory tree (after every op) so a
+        // later op that overwrote / truncated the same file simply
+        // updates the expectation. A path may have been renamed
+        // away or unlinked by a later op; only those still present
+        // in-memory carry an expectation, and the assertion further
+        // tolerates a path missing post-reload (a later rename).
+        let mut expected_falloc: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+        for path in &exp.fallocated {
+            if let Some(ino) = tree.resolve_path(Path::new(path))
+                && let Some(node) = tree.get(ino)
+                && let FsContent::File(fc) = &node.content
+            {
+                expected_falloc.insert(path.clone(), fc.data().to_vec());
+            }
+        }
+
         archive_io::save(&mut tree).unwrap();
 
         let after_mutated_save = archive_io::load(&archive, None).unwrap();
@@ -1389,6 +1533,7 @@ proptest! {
         assert_no_orphan_inodes(&after_mutated_save)?;
         assert_file_size_matches_content(&snap_first)?;
         assert_mutation_hardlinks_equivalent(&snap_first, &exp.placed_links)?;
+        assert_fallocate_round_trips(&snap_first, &expected_falloc)?;
 
         // Idempotence under the mutated state: a second cycle from
         // here must reach the same snapshot. If a mutation produced

--- a/src/roundtrip_proptest.rs
+++ b/src/roundtrip_proptest.rs
@@ -412,8 +412,11 @@ struct Expectations {
 fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
     let mut exp = Expectations::default();
     for op in ops {
-        let files = collect_file_paths(tree);
-        let any_paths = collect_all_paths(tree);
+        // One DFS traversal per op (still recomputed every iteration
+        // so it reflects the tree state left by prior ops); the three
+        // path inventories are derived from that single walk instead
+        // of re-traversing the tree once per helper / per arm.
+        let (files, dirs, any_paths) = collect_inventories(tree);
         match op {
             FsOp::WriteOver { target, content } => {
                 if files.is_empty() {
@@ -458,7 +461,6 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
                 let _ = tree.unlink(parent_ino, &leaf);
             }
             FsOp::Mkdir { parent, name } => {
-                let dirs = collect_dir_paths(tree);
                 if dirs.is_empty() {
                     continue;
                 }
@@ -474,7 +476,6 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
                 let _ = tree.make_dir(parent_ino, OsStr::new(name), 0o755, 0, Owner::new(0, 0));
             }
             FsOp::Rmdir { target } => {
-                let dirs = collect_dir_paths(tree);
                 // Skip the root: rmdir on `/` is meaningless and the
                 // generator picking it would just contribute to the
                 // empty-op rate.
@@ -541,7 +542,6 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
                 if nonroot.is_empty() {
                     continue;
                 }
-                let dirs = collect_dir_paths(tree);
                 let src_path = nonroot[source.index(nonroot.len())];
                 let Some((old_parent, old_leaf)) = split_parent_leaf(tree, src_path) else {
                     continue;
@@ -586,7 +586,6 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
                 if files.is_empty() {
                     continue;
                 }
-                let dirs = collect_dir_paths(tree);
                 let source_path = &files[source.index(files.len())];
                 let Some(source_ino) = tree.resolve_path(Path::new(source_path)) else {
                     continue;
@@ -642,39 +641,36 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
     exp
 }
 
-/// Snapshot of every File path visible in `tree`, DFS-ordered. All
-/// `collect_*_paths` helpers return POSIX-relative paths with no
-/// leading `/`; the archive root is the empty string, and a file
-/// `f.txt` directly under root is just `"f.txt"`. Callers that need
-/// to split parent / leaf must therefore special-case the empty
-/// parent as `ROOT_INODE`.
-fn collect_file_paths(tree: &FileTree) -> Vec<String> {
-    tree.collect_dfs()
-        .into_iter()
-        .filter_map(|(_ino, node, path)| matches!(node.content, FsContent::File(_)).then_some(path))
-        .collect()
-}
-
-/// Snapshot of every Directory path visible in `tree`, DFS-ordered.
-/// Includes the root, represented as the empty string.
-fn collect_dir_paths(tree: &FileTree) -> Vec<String> {
-    let mut paths: Vec<String> = vec![String::new()];
-    paths.extend(
-        tree.collect_dfs()
-            .into_iter()
-            .filter_map(|(_ino, node, path)| {
-                matches!(node.content, FsContent::Directory(_)).then_some(path)
-            }),
-    );
-    paths
-}
-
-/// Snapshot of every observable path (files + dirs + symlinks +
-/// specials + the root, represented as the empty string).
-fn collect_all_paths(tree: &FileTree) -> Vec<String> {
-    let mut paths: Vec<String> = vec![String::new()];
-    paths.extend(tree.collect_dfs().into_iter().map(|(_, _, p)| p));
-    paths
+/// Derive the three path inventories an op may need from a **single**
+/// `collect_dfs()` traversal, returned as `(files, dirs, all)`:
+///
+/// * `files` — every File path, DFS-ordered, no root entry.
+/// * `dirs`  — the root (empty string) followed by every Directory
+///   path, DFS-ordered.
+/// * `all`   — the root (empty string) followed by every observable
+///   path (files + dirs + symlinks + specials), DFS-ordered.
+///
+/// All paths are POSIX-relative with no leading `/`; the archive root
+/// is the empty string, and a file `f.txt` directly under root is
+/// just `"f.txt"`. Callers that split parent / leaf must therefore
+/// special-case the empty parent as `ROOT_INODE`. Each list is
+/// byte-for-byte what the former per-kind helpers produced — this is
+/// purely a de-duplication of the redundant per-op / per-helper DFS
+/// walks, not a change to ordering or contents.
+fn collect_inventories(tree: &FileTree) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let dfs = tree.collect_dfs();
+    let mut files = Vec::new();
+    let mut dirs = vec![String::new()];
+    let mut all = vec![String::new()];
+    for (_ino, node, path) in dfs {
+        match node.content {
+            FsContent::File(_) => files.push(path.clone()),
+            FsContent::Directory(_) => dirs.push(path.clone()),
+            _ => {}
+        }
+        all.push(path);
+    }
+    (files, dirs, all)
 }
 
 /// Split a POSIX-relative path (no leading `/`, root = `""`) into its

--- a/src/roundtrip_proptest.rs
+++ b/src/roundtrip_proptest.rs
@@ -235,6 +235,35 @@ enum FsOp {
         target_any: proptest::sample::Index,
         name: String,
     },
+    /// Rename some existing entry into a (possibly different)
+    /// directory under a new name. `source` indexes the live
+    /// non-root inventory; `dest_dir` indexes the live directory
+    /// inventory (root included). `mode` selects plain rename,
+    /// `RENAME_NOREPLACE`, or `RENAME_EXCHANGE`. Same-parent and
+    /// cross-parent moves both arise naturally (the generator does
+    /// not constrain `dest_dir` to differ from the source's parent),
+    /// as does a destination that already exists.
+    Rename {
+        source: proptest::sample::Index,
+        dest_dir: proptest::sample::Index,
+        dest_name: String,
+        mode: RenameMode,
+    },
+}
+
+/// Which flavour of `rename(2)` an `FsOp::Rename` issues. Splitting
+/// this out (rather than generating raw `fuser::RenameFlags`) keeps
+/// the shrinker working on a small closed set and documents intent.
+#[derive(Debug, Clone, Copy)]
+enum RenameMode {
+    /// Plain rename: clobbers the destination if it exists.
+    Plain,
+    /// `RENAME_NOREPLACE`: `EEXIST` (skipped) if the destination
+    /// exists.
+    NoReplace,
+    /// `RENAME_EXCHANGE`: atomically swap two existing entries;
+    /// `ENOENT` (skipped) if the destination does not exist.
+    Exchange,
 }
 
 fn arb_fs_op() -> impl Strategy<Value = FsOp> {
@@ -253,6 +282,26 @@ fn arb_fs_op() -> impl Strategy<Value = FsOp> {
             .prop_map(|(target_any, name, value)| FsOp::SetXattr { target_any, name, value }),
         1 => (any::<proptest::sample::Index>(), arb_xattr_name())
             .prop_map(|(target_any, name)| FsOp::RemoveXattr { target_any, name }),
+        3 => (
+            any::<proptest::sample::Index>(),
+            any::<proptest::sample::Index>(),
+            arb_segment(),
+            arb_rename_mode(),
+        )
+            .prop_map(|(source, dest_dir, dest_name, mode)| FsOp::Rename {
+                source,
+                dest_dir,
+                dest_name,
+                mode,
+            }),
+    ]
+}
+
+fn arb_rename_mode() -> impl Strategy<Value = RenameMode> {
+    prop_oneof![
+        3 => Just(RenameMode::Plain),
+        1 => Just(RenameMode::NoReplace),
+        1 => Just(RenameMode::Exchange),
     ]
 }
 
@@ -376,6 +425,52 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) {
                     let _ = tree.removexattr(ino, name);
                 }
             }
+            FsOp::Rename {
+                source,
+                dest_dir,
+                dest_name,
+                mode,
+            } => {
+                // Source is any non-root entry; dest parent is any
+                // live directory (root included). `dest_dir` is not
+                // constrained to differ from the source's parent, so
+                // both same-parent and cross-parent moves arise.
+                let nonroot: Vec<&String> = any_paths.iter().filter(|p| !p.is_empty()).collect();
+                if nonroot.is_empty() {
+                    continue;
+                }
+                let dirs = collect_dir_paths(tree);
+                let src_path = nonroot[source.index(nonroot.len())];
+                let Some((old_parent, old_leaf)) = split_parent_leaf(tree, src_path) else {
+                    continue;
+                };
+                let dest_dir_path = &dirs[dest_dir.index(dirs.len())];
+                let new_parent = if dest_dir_path.is_empty() {
+                    ROOT_INODE
+                } else {
+                    match tree.resolve_path(Path::new(dest_dir_path)) {
+                        Some(i) => i,
+                        None => continue,
+                    }
+                };
+                let flags = match mode {
+                    RenameMode::Plain => fuser::RenameFlags::empty(),
+                    RenameMode::NoReplace => fuser::RenameFlags::RENAME_NOREPLACE,
+                    RenameMode::Exchange => fuser::RenameFlags::RENAME_EXCHANGE,
+                };
+                // Every rejected case (ENOENT, EEXIST under
+                // NOREPLACE, ENOENT under EXCHANGE, EINVAL for a dir
+                // into its own descendant, ENOTEMPTY clobbering a
+                // populated dir) is a silently-skipped op, matching
+                // the rest of the state machine.
+                let _ = tree.rename(
+                    old_parent,
+                    &old_leaf,
+                    new_parent,
+                    OsStr::new(dest_name),
+                    flags,
+                );
+            }
         }
     }
 }
@@ -413,6 +508,22 @@ fn collect_all_paths(tree: &FileTree) -> Vec<String> {
     let mut paths: Vec<String> = vec![String::new()];
     paths.extend(tree.collect_dfs().into_iter().map(|(_, _, p)| p));
     paths
+}
+
+/// Split a POSIX-relative path (no leading `/`, root = `""`) into its
+/// `(parent_inode, leaf_name)`, resolving the parent against `tree`.
+/// Returns `None` if the path is the root, has no file name, or the
+/// parent does not resolve — every one of which an `FsOp` arm treats
+/// as "skip this op", matching the existing inline style in
+/// `UnlinkFile` / `Rmdir`.
+fn split_parent_leaf(tree: &FileTree, path: &str) -> Option<(Inode, std::ffi::OsString)> {
+    let path_buf = Path::new(path);
+    let leaf = path_buf.file_name()?.to_owned();
+    let parent_ino = match path_buf.parent() {
+        Some(p) if !p.as_os_str().is_empty() => tree.resolve_path(p)?,
+        _ => ROOT_INODE,
+    };
+    Some((parent_ino, leaf))
 }
 
 // ── Generators ─────────────────────────────────────────────────────

--- a/src/roundtrip_proptest.rs
+++ b/src/roundtrip_proptest.rs
@@ -249,6 +249,17 @@ enum FsOp {
         dest_name: String,
         mode: RenameMode,
     },
+    /// Hardlink some existing non-directory entry under a new name in
+    /// a (possibly different) directory. `source` indexes the live
+    /// non-root inventory; `dest_dir` indexes the live directory
+    /// inventory. Directory sources (EPERM), symlink/special sources
+    /// (the FS API only hardlinks regular-file inodes meaningfully),
+    /// and name collisions (EEXIST) are silently skipped.
+    Link {
+        source: proptest::sample::Index,
+        dest_dir: proptest::sample::Index,
+        dest_name: String,
+    },
 }
 
 /// Which flavour of `rename(2)` an `FsOp::Rename` issues. Splitting
@@ -294,6 +305,16 @@ fn arb_fs_op() -> impl Strategy<Value = FsOp> {
                 dest_name,
                 mode,
             }),
+        2 => (
+            any::<proptest::sample::Index>(),
+            any::<proptest::sample::Index>(),
+            arb_segment(),
+        )
+            .prop_map(|(source, dest_dir, dest_name)| FsOp::Link {
+                source,
+                dest_dir,
+                dest_name,
+            }),
     ]
 }
 
@@ -305,10 +326,24 @@ fn arb_rename_mode() -> impl Strategy<Value = RenameMode> {
     ]
 }
 
-/// Apply `ops` to `tree`, silently skipping invalid ones. Returns
-/// nothing — the assertion lives in the property that calls this,
-/// after a save + reload.
-fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) {
+/// What `apply_ops` materialised, for the post-reload assertions the
+/// generic invariants (nlink, size==content, idempotence) do not pin.
+#[derive(Debug, Default)]
+struct Expectations {
+    /// `(source_path, dest_path)` for every hardlink an `FsOp::Link`
+    /// actually created. Recorded at creation time; either path may
+    /// be renamed / unlinked by a *later* op, so the assertion only
+    /// checks pairs whose both ends still resolve after reload.
+    placed_links: Vec<(String, String)>,
+}
+
+/// Apply `ops` to `tree`, silently skipping invalid ones. Returns the
+/// hardlinks created so the calling property can assert their
+/// round-trip; the generic invariants (directory nlink,
+/// size==content, idempotence) are still checked by the property
+/// regardless.
+fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
+    let mut exp = Expectations::default();
     for op in ops {
         let files = collect_file_paths(tree);
         let any_paths = collect_all_paths(tree);
@@ -471,8 +506,53 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) {
                     flags,
                 );
             }
+            FsOp::Link {
+                source,
+                dest_dir,
+                dest_name,
+            } => {
+                // Source is restricted to regular files: directory
+                // sources are EPERM, and the FS API deliberately does
+                // not support hardlink-to-symlink (issue #432), so
+                // those are simply never proposed here rather than
+                // generated-then-skipped.
+                if files.is_empty() {
+                    continue;
+                }
+                let dirs = collect_dir_paths(tree);
+                let source_path = &files[source.index(files.len())];
+                let Some(source_ino) = tree.resolve_path(Path::new(source_path)) else {
+                    continue;
+                };
+                let dest_dir_path = &dirs[dest_dir.index(dirs.len())];
+                let dest_path = if dest_dir_path.is_empty() {
+                    dest_name.clone()
+                } else {
+                    format!("{dest_dir_path}/{dest_name}")
+                };
+                if dest_path == *source_path {
+                    continue;
+                }
+                let dest_parent_ino = if dest_dir_path.is_empty() {
+                    ROOT_INODE
+                } else {
+                    match tree.resolve_path(Path::new(dest_dir_path)) {
+                        Some(i) => i,
+                        None => continue,
+                    }
+                };
+                // EEXIST on collision is one of the silently-skipped
+                // cases; only record links that actually materialise.
+                if tree
+                    .create_hardlink(dest_parent_ino, OsStr::new(dest_name), source_ino)
+                    .is_ok()
+                {
+                    exp.placed_links.push((source_path.clone(), dest_path));
+                }
+            }
         }
     }
+    exp
 }
 
 /// Snapshot of every File path visible in `tree`, DFS-ordered. All
@@ -1186,6 +1266,30 @@ fn assert_hardlinks_equivalent(
     Ok(())
 }
 
+/// SPEC: a hardlink created mid-mutation still observes the same
+/// node as its source after `save → load` — *where both ends
+/// survived*. Unlike `assert_hardlinks_equivalent`, a missing end is
+/// tolerated: a later `FsOp` in the same sequence may have renamed or
+/// unlinked either path, which is legitimate and not a round-trip
+/// bug. Only the surviving pairs are asserted equal.
+fn assert_mutation_hardlinks_equivalent(
+    snap: &BTreeMap<String, ObservedNode>,
+    placed_links: &[(String, String)],
+) -> Result<(), TestCaseError> {
+    for (src, dst) in placed_links {
+        if let (Some(src_obs), Some(dst_obs)) = (snap.get(src), snap.get(dst)) {
+            prop_assert_eq!(
+                src_obs,
+                dst_obs,
+                "post-mutation hardlink content/metadata mismatch between {} and {}",
+                src,
+                dst
+            );
+        }
+    }
+    Ok(())
+}
+
 proptest! {
     // Plaintext properties: 64 cases keeps `cargo test` under a few
     // seconds locally. The scheduled CI job runs at
@@ -1276,7 +1380,7 @@ proptest! {
 
         build_and_save(&archive, &input).unwrap();
         let mut tree = archive_io::load(&archive, None).unwrap();
-        apply_ops(&mut tree, &ops);
+        let exp = apply_ops(&mut tree, &ops);
         archive_io::save(&mut tree).unwrap();
 
         let after_mutated_save = archive_io::load(&archive, None).unwrap();
@@ -1284,6 +1388,7 @@ proptest! {
         assert_directory_nlink_posix(&snap_first)?;
         assert_no_orphan_inodes(&after_mutated_save)?;
         assert_file_size_matches_content(&snap_first)?;
+        assert_mutation_hardlinks_equivalent(&snap_first, &exp.placed_links)?;
 
         // Idempotence under the mutated state: a second cycle from
         // here must reach the same snapshot. If a mutation produced


### PR DESCRIPTION
## Summary

Extends the `plain_mutation_sequence_survives_save_load` property in
`src/roundtrip_proptest.rs` with three new `FsOp` variants, one focused
commit per issue:

- **#431 `FsOp::Rename`** — plain / `RENAME_NOREPLACE` / `RENAME_EXCHANGE`.
  Same-parent and cross-parent moves and a pre-existing destination all
  arise naturally from the generator; every rejected case (ENOENT,
  EEXIST under NOREPLACE, ENOENT under EXCHANGE, dir-into-descendant,
  ENOTEMPTY) is a silently-skipped op, matching the existing
  mutation-op style.
- **#432 `FsOp::Link`** — hardlink a regular-file source under a new
  name in any live directory. Directory sources (EPERM) and
  hardlink-to-symlink (intentionally unsupported by the FS API per the
  issue note) are never proposed; EEXIST collisions are skipped.
  `apply_ops` now returns the links it materialised so the property
  asserts each linked pair is observationally equivalent after
  save/reload — tolerating a pair whose end a later op renamed or
  unlinked.
- **#433 `FsOp::Fallocate`** — mode 0 grow, `PUNCH_HOLE|KEEP_SIZE`,
  `ZERO_RANGE`. The generator only emits these three supported
  flavours; non-file targets / zero length are skipped. The property
  captures each touched file's final in-memory bytes before save and
  asserts size + exact contents survive save/reload (sparseness is not
  asserted, only observable read-back bytes, per the issue note).

Only `src/roundtrip_proptest.rs` is touched. Invalid generated ops stay
skipped; shrinking remains monotonic (targets indexed into the live
inventory recomputed per op, closed-set mode enums).

Closes #431, closes #432, closes #433.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo test --locked --release` — 176/176 pass
- [x] `PROPTEST_CASES=2000 cargo test --release plain_mutation_sequence_survives_save_load` — pass, no round-trip bug found
- [x] No round-trip bug surfaced by the new ops

## Pre-existing clippy (not introduced here)

`cargo clippy --locked --all-targets --all-features -- -D warnings`
reports 12 errors that exist on the clean branch base
(unchanged by this PR; this diff adds **zero** new clippy findings):

- `src/archive_io.rs:867,898,943,947` — `save` doesn't need `&mut`
- `src/file_tree.rs:2653` — `archive_io::save` doesn't need `&mut`
- `src/file_tree.rs:2686,2702` — unnecessary `as u64` cast
- `src/roundtrip_proptest.rs` (pre-existing lines) — old `archive_io::save(&mut)` call sites + one `type_complexity` on `build_save_load`'s return

These stem from `archive_io::save` taking an unnecessary `&mut FileTree`
plus older lints; fixing them is cross-cutting (touches `archive_io.rs`
/ `file_tree.rs`, other worktrees) and out of scope for #431–#433. Repo
CI clippy runs without `-D warnings` (SARIF report only), so these do
not red-fail CI.