### PR TITLE
:memo: Move special-files note into Troubleshooting (#437)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,21 +61,6 @@ Mount archive:
 $ pnafs mount archive.pna /mnt/pnafs/
 ```
 
-#### Special files are not persisted
-
-Special files — named pipes (fifo), sockets, and device nodes — are
-supported only in memory while a writable archive is mounted. The PNA
-format has no on-disk representation for them, so they are dropped
-(with a warning) when the archive is saved. Any such node you
-create while mounted will disappear from the archive once it is written
-back; this is a data-loss risk, so avoid relying on special files inside
-a PNA-FS mount.
-
-```bash
-$ mkfifo /mnt/pnafs/pipe   # exists during the mount
-$ # ...after unmount and reload, /mnt/pnafs/pipe is gone
-```
-
 ### Testing
 
 ```bash
@@ -97,4 +82,19 @@ This error occurs when `user_allow_other` is not set in `/etc/fuse.conf` or the 
 # echo 'user_allow_other' >> /etc/fuse.conf
 # chmod 644 /etc/fuse.conf
 # sudo chown root:root /etc/fuse.conf
+```
+
+#### Special files are not persisted
+
+Special files — named pipes (fifo), sockets, and device nodes — are
+supported only in memory while a writable archive is mounted. The PNA
+format has no on-disk representation for them, so they are dropped
+(with a warning) when the archive is saved. Any such node you
+create while mounted will disappear from the archive once it is written
+back; this is a data-loss risk, so avoid relying on special files inside
+a PNA-FS mount.
+
+```bash
+$ mkfifo /mnt/pnafs/pipe   # exists during the mount
+$ # ...after unmount and reload, /mnt/pnafs/pipe is gone
 ```


### PR DESCRIPTION
## Summary
Post-merge follow-up to #441, addressing the CodeRabbit review comment that the
special-files data-loss note belongs in the existing `### Troubleshooting`
section rather than under Usage.

- Pure relocation of the `#### Special files are not persisted` subsection from
  the Usage area into the existing `### Troubleshooting` section.
- Wording and the `mkfifo` example are unchanged; heading level (`####`) matches
  the sibling Troubleshooting subsection.
- No other content changes (diff is 15 ins / 15 del, all identical lines moved).

Refs #437. Follow-up to #441 (already merged).

## Test plan
- [x] `cargo fmt --check` passes (docs-only change)
- [x] `git diff` confirms a pure move (no wording/example change)
- [x] README renders with the note under Troubleshooting alongside the mount-error entry