### PR TITLE
:green_heart: Stop fsx issuing 0-length posix_fallocate (fsx.toml opsize min=1)

### DIFF
--- a/scripts/tests/fsx.toml
+++ b/scripts/tests/fsx.toml
@@ -17,7 +17,7 @@ nomsyncafterwrite = true
 
 [opsize]
 max = 65536
-min = 0
+min = 1
 align = 1
 
 [weights]


### PR DESCRIPTION
Closes #448.

## Summary
One-line change: `scripts/tests/fsx.toml` `[opsize]` `min = 0` → `min = 1`. No other file; no pnafs source change.

## Root cause (from the #448 / Task #12 investigation)
With `[opsize] min = 0`, fsx-rs occasionally rolls a **0-length `posix_fallocate`**. glibc returns `EINVAL` for `posix_fallocate(fd, _, 0)` on **every** filesystem (POSIX-mandated; it short-circuits before reaching the kernel/FUSE — pnafs's own POSIX-correct `EINVAL` for `length == 0` is never even reached). fsx-rs at the pinned ref treats `EINVAL`/`EOPNOTSUPP` from `posix_fallocate` as "filesystem unsupported" and aborts the run — and, unlike `read`/`punch_hole`, it has **no `len == 0` skip guard** for `posix_fallocate`. Whether a 0-length fallocate appears within a run is purely seed-dependent, so the `fsx` CI job failed **intermittently** on unrelated PRs (e.g. it false-failed docs-only #446; a re-run passed).

pnafs is **not** buggy here — its behaviour is POSIX-correct. This is a test-config flake, fixed entirely in the harness config.

## Why `min = 1` is safe (no coverage loss)
A 0-byte operation is a no-op or an error for every exercised op (read/write/fallocate/punch_hole). fsx-rs already `Skip`s `len == 0` for `read` and `punch_hole`; raising the floor to 1 simply makes `posix_fallocate` consistent with them and removes the only flake source without losing any real coverage.

## Verification (this Linux FUSE host)
1. **Regression-proof** — the exact seed that deterministically failed before:
   `FSX_SEED=3892845879852811221 FSX_NUMOPS=50000 scripts/tests/test_fsx.sh`
   → `All operations completed A-OK!` / `fsx run complete (no failures).` / exit 0.
   (Before this change, this seed failed deterministically at `op 43647 POSIX_FALLOCATE 0x25912 => 0x25911 (0x0 bytes)`.)
2. **Sanity** — fresh default run, random seed, default `FSX_NUMOPS=50000`:
   → `All operations completed A-OK!` / `fsx run complete (no failures).` / exit 0.

## Test plan
- [x] Previously-failing seed now passes (regression fixed)
- [x] Fresh random-seed default run still passes (no behaviour/coverage breakage)
- [x] Diff is exactly one line; no pnafs src change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted test configuration parameters to refine testing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Portable-Network-Archive/fs/pull/449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->