### PR TITLE
:rotating_light: Clear pre-existing clippy findings

### DIFF
--- a/src/archive_io.rs
+++ b/src/archive_io.rs
@@ -864,7 +864,7 @@ mod tests {
         let mut tree = tree;
         // Touch the file to flip Clean -> Dirty so save will rewrite it.
         tree.write_file(ino, 0, b"x").unwrap();
-        save(&mut tree).unwrap();
+        save(&tree).unwrap();
         let reloaded = load(&path, None).unwrap();
         let (_, node) = reloaded
             .children(ROOT_INODE)
@@ -895,7 +895,7 @@ mod tests {
         let ino = node.attr.ino.0;
         // Touch the file to flip Clean -> Dirty so save will rewrite it.
         tree.write_file(ino, 0, b"x").unwrap();
-        save(&mut tree).unwrap();
+        save(&tree).unwrap();
 
         // Reload **without** the password — if save re-encrypted, this
         // would now require one and decoding `b"plaintext-bytes"` would
@@ -940,11 +940,11 @@ mod tests {
         // output if iteration ever became insertion-order-dependent.
         tree.setxattr(ino, "user.zz", b"late", 0).unwrap();
         tree.setxattr(ino, "user.aa", b"early", 0).unwrap();
-        save(&mut tree).unwrap();
+        save(&tree).unwrap();
         let bytes_first = std::fs::read(&path).unwrap();
 
-        let mut tree2 = load(&path, None).unwrap();
-        save(&mut tree2).unwrap();
+        let tree2 = load(&path, None).unwrap();
+        save(&tree2).unwrap();
         let bytes_second = std::fs::read(&path).unwrap();
 
         assert_eq!(

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -2650,7 +2650,7 @@ mod tests {
             .unwrap();
         let ino = node.attr.ino.0;
         tree.setxattr(ino, "user.color", b"green", 0).unwrap();
-        crate::archive_io::save(&mut tree).unwrap();
+        crate::archive_io::save(&tree).unwrap();
 
         let reloaded = crate::archive_io::load(&archive, None).unwrap();
         let (_, n) = reloaded
@@ -2682,13 +2682,8 @@ mod tests {
     #[test]
     fn get_uid_preserves_archive_id_when_name_does_not_resolve() {
         // gname empty + numeric id that is unlikely to exist in /etc/group.
-        let permission = pna::Permission::new(
-            0xfeed_face as u64,
-            String::new(),
-            0u64,
-            String::new(),
-            0o644,
-        );
+        let permission =
+            pna::Permission::new(0xfeed_faceu64, String::new(), 0u64, String::new(), 0o644);
         let uid = get_uid(Some(&permission));
         // Archive uid must round-trip even though there's no local user.
         assert_eq!(uid, 0xfeed_face);
@@ -2696,13 +2691,8 @@ mod tests {
 
     #[test]
     fn get_gid_preserves_archive_id_when_name_does_not_resolve() {
-        let permission = pna::Permission::new(
-            0u64,
-            String::new(),
-            0xdead_beef as u64,
-            String::new(),
-            0o644,
-        );
+        let permission =
+            pna::Permission::new(0u64, String::new(), 0xdead_beefu64, String::new(), 0o644);
         let gid = get_gid(Some(&permission));
         assert_eq!(gid, 0xdead_beef);
     }

--- a/src/roundtrip_proptest.rs
+++ b/src/roundtrip_proptest.rs
@@ -1118,7 +1118,7 @@ fn build_and_save(archive_path: &Path, input: &TestInput) -> io::Result<Vec<(Str
         build_child(&mut tree, ROOT_INODE, name, spec)?;
     }
     let placed = apply_hardlinks(&mut tree, &input.root, &input.hardlinks);
-    archive_io::save(&mut tree)?;
+    archive_io::save(&tree)?;
     Ok(placed)
 }
 
@@ -1200,17 +1200,19 @@ enum Observed {
 // reload so each property doesn't replay the costly part of the
 // pipeline four times over.
 
-/// Common preamble: build the spec into a fresh archive, save, load
-/// once. Returns (placed hardlinks, post-load snapshot, raw archive
-/// bytes).
-fn build_save_load(
-    input: &TestInput,
-    archive: &Path,
-) -> (
+/// `(placed hardlinks, post-load snapshot, raw archive bytes)` — the
+/// cached result of one `build_and_save` + reload that the per-SPEC
+/// properties share.
+type BuildSaveLoad = (
     Vec<(String, String)>,
     BTreeMap<String, ObservedNode>,
     Vec<u8>,
-) {
+);
+
+/// Common preamble: build the spec into a fresh archive, save, load
+/// once. Returns (placed hardlinks, post-load snapshot, raw archive
+/// bytes).
+fn build_save_load(input: &TestInput, archive: &Path) -> BuildSaveLoad {
     let placed_links = build_and_save(archive, input).unwrap();
     let tree = archive_io::load(archive, input.password.clone()).unwrap();
     let snap = snapshot(&tree);
@@ -1244,8 +1246,8 @@ fn assert_save_is_idempotent(
     archive: &Path,
     snap_first: &BTreeMap<String, ObservedNode>,
 ) -> Result<(), TestCaseError> {
-    let mut tree = archive_io::load(archive, input.password.clone()).unwrap();
-    archive_io::save(&mut tree).unwrap();
+    let tree = archive_io::load(archive, input.password.clone()).unwrap();
+    archive_io::save(&tree).unwrap();
     let after_second_load = archive_io::load(archive, input.password.clone()).unwrap();
     let snap_second = snapshot(&after_second_load);
     prop_assert_eq!(snap_first, &snap_second, "second round-trip drifted");
@@ -1521,7 +1523,7 @@ proptest! {
             }
         }
 
-        archive_io::save(&mut tree).unwrap();
+        archive_io::save(&tree).unwrap();
 
         let after_mutated_save = archive_io::load(&archive, None).unwrap();
         let snap_first = snapshot(&after_mutated_save);
@@ -1550,8 +1552,8 @@ proptest! {
         build_and_save(&archive, &input).unwrap();
         let bytes_first = std::fs::read(&archive).unwrap();
 
-        let mut tree = archive_io::load(&archive, None).unwrap();
-        archive_io::save(&mut tree).unwrap();
+        let tree = archive_io::load(&archive, None).unwrap();
+        archive_io::save(&tree).unwrap();
         let bytes_second = std::fs::read(&archive).unwrap();
 
         prop_assert_eq!(


### PR DESCRIPTION
## Summary

Mechanical, zero-behaviour-change cleanup of the 12 clippy lints that
were present on a clean `main` checkout (clippy without `-D warnings`
reports them as `warning:`; this PR removes them so the report is
clean). No production logic is touched — all changes are in test /
helper code.

- **`unnecessary_mut_passed` (9)** — `archive_io::save` already takes
  `&FileTree`, so every `save(&mut x)` caller becomes `save(&x)`
  (4× `src/archive_io.rs`, 1× `src/file_tree.rs`, 4×
  `src/roundtrip_proptest.rs`). Three bindings whose *only* mutation
  was the now-removed `&mut` drop their `mut` so no new `unused_mut`
  is introduced.
- **`unnecessary_cast` (2)** — drop the redundant `as u64` on the
  `0xfeed_face` / `0xdead_beef` literals in `src/file_tree.rs` tests
  (use the `u64` literal suffix, matching the adjacent `0u64`).
- **`type_complexity` (1)** — name `build_save_load`'s 3-tuple return
  as a transparent `BuildSaveLoad` type alias in
  `src/roundtrip_proptest.rs`; all call sites are unchanged.

Not tied to a feature issue — this clears the pre-existing debt noted
in the #431–433 and #436 PRs.

## Clippy finding counts

- **Before** (clean `main`, ef0e0c1): **12** findings
  (9 `unnecessary_mut_passed`, 2 `unnecessary_cast`, 1 `type_complexity`)
- **After**: **0** findings, **0** new ones introduced

## Test plan

- [x] `cargo clippy --locked --all-targets --all-features` — 12 prior findings gone, zero new
- [x] `cargo fmt --check` — clean
- [x] `cargo test --locked --release` — 183/183 pass