### PR TITLE
:white_check_mark: Extend mutation proptest ops + add encrypted mutation property (Closes #458, Closes #459)

### DIFF
--- a/src/roundtrip_proptest.rs
+++ b/src/roundtrip_proptest.rs
@@ -271,6 +271,41 @@ enum FsOp {
         length: u64,
         mode: FallocMode,
     },
+    /// Create a symlink under some existing directory parent. `parent`
+    /// indexes the live directory inventory (root included); a name
+    /// collision returns `EEXIST` and the op is silently skipped. The
+    /// target is an arbitrary path-shaped string (not required to
+    /// resolve — dangling symlinks round-trip too).
+    SymlinkCreate {
+        parent: proptest::sample::Index,
+        name: String,
+        target: String,
+    },
+    /// `chmod` / `chown` on some existing inode (POSIX `setattr`).
+    /// `target_any` indexes the live observable inventory (root
+    /// included). Each of `perm` / `uid` / `gid` is applied only when
+    /// `Some`, so the op covers chmod-only, chown-only, and combined
+    /// changes. uid / gid use the same synthetic high ranges as
+    /// `arb_meta` so the byte-identity / idempotence properties stay
+    /// host-independent.
+    SetAttr {
+        target_any: proptest::sample::Index,
+        perm: Option<u16>,
+        uid: Option<u32>,
+        gid: Option<u32>,
+    },
+    /// `copy_file_range(2)` from one existing File to another (or the
+    /// same one). `src` / `dst` index the live File inventory;
+    /// offsets / length stay small so copies land in or just past
+    /// EOF. Non-file endpoints or a length that copies nothing return
+    /// an errno / zero and the op is silently skipped.
+    CopyFileRange {
+        src: proptest::sample::Index,
+        dst: proptest::sample::Index,
+        src_offset: u64,
+        dst_offset: u64,
+        len: u64,
+    },
 }
 
 /// Which flavour of `rename(2)` an `FsOp::Rename` issues. Splitting
@@ -368,6 +403,42 @@ fn arb_fs_op() -> impl Strategy<Value = FsOp> {
                 offset,
                 length,
                 mode,
+            }),
+        2 => (
+            any::<proptest::sample::Index>(),
+            arb_segment(),
+            arb_symlink_target(),
+        )
+            .prop_map(|(parent, name, target)| FsOp::SymlinkCreate {
+                parent,
+                name,
+                target,
+            }),
+        2 => (
+            any::<proptest::sample::Index>(),
+            prop::option::of(prop::num::u16::ANY.prop_map(|m| m & 0o7777)),
+            prop::option::of(0xFEED_0000_u32..=0xFEED_FFFF_u32),
+            prop::option::of(0xDEAD_0000_u32..=0xDEAD_FFFF_u32),
+        )
+            .prop_map(|(target_any, perm, uid, gid)| FsOp::SetAttr {
+                target_any,
+                perm,
+                uid,
+                gid,
+            }),
+        2 => (
+            any::<proptest::sample::Index>(),
+            any::<proptest::sample::Index>(),
+            0u64..=8192,
+            0u64..=8192,
+            1u64..=8192,
+        )
+            .prop_map(|(src, dst, src_offset, dst_offset, len)| FsOp::CopyFileRange {
+                src,
+                dst,
+                src_offset,
+                dst_offset,
+                len,
             }),
     ]
 }
@@ -635,6 +706,73 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
                         exp.fallocated.insert(path);
                     }
                 }
+            }
+            FsOp::SymlinkCreate {
+                parent,
+                name,
+                target,
+            } => {
+                // `dirs` always holds at least the root (""), so it
+                // is never empty. A name collision under the chosen
+                // parent makes `create_symlink` return EEXIST, which
+                // is one of the silently-skipped cases.
+                let parent_path = &dirs[parent.index(dirs.len())];
+                let parent_ino = if parent_path.is_empty() {
+                    ROOT_INODE
+                } else {
+                    match tree.resolve_path(Path::new(parent_path)) {
+                        Some(i) => i,
+                        None => continue,
+                    }
+                };
+                let _ = tree.create_symlink(
+                    parent_ino,
+                    OsStr::new(name),
+                    Path::new(target),
+                    Owner::new(0, 0),
+                );
+            }
+            FsOp::SetAttr {
+                target_any,
+                perm,
+                uid,
+                gid,
+            } => {
+                if any_paths.is_empty() {
+                    continue;
+                }
+                let path = &any_paths[target_any.index(any_paths.len())];
+                if let Some(ino) = if path.is_empty() {
+                    Some(ROOT_INODE)
+                } else {
+                    tree.resolve_path(Path::new(path))
+                } {
+                    let _ = tree.set_attr_full(ino, perm.map(u32::from), *uid, *gid);
+                }
+            }
+            FsOp::CopyFileRange {
+                src,
+                dst,
+                src_offset,
+                dst_offset,
+                len,
+            } => {
+                if files.is_empty() {
+                    continue;
+                }
+                let src_path = &files[src.index(files.len())];
+                let dst_path = &files[dst.index(files.len())];
+                let (Some(src_ino), Some(dst_ino)) = (
+                    tree.resolve_path(Path::new(src_path)),
+                    tree.resolve_path(Path::new(dst_path)),
+                ) else {
+                    continue;
+                };
+                // Non-file endpoints (EISDIR/EINVAL) or a copy that
+                // moves nothing (Ok(0)) leave the tree unchanged; the
+                // generic post-reload invariants still cover whatever
+                // bytes did land.
+                let _ = tree.copy_file_range(src_ino, *src_offset, dst_ino, *dst_offset, *len);
             }
         }
     }

--- a/src/roundtrip_proptest.rs
+++ b/src/roundtrip_proptest.rs
@@ -468,11 +468,14 @@ struct Expectations {
     /// be renamed / unlinked by a *later* op, so the assertion only
     /// checks pairs whose both ends still resolve after reload.
     placed_links: Vec<(String, String)>,
-    /// Paths an `FsOp::Fallocate` touched, deduplicated. The expected
-    /// post-reload bytes are read from the *final* in-memory tree
-    /// (after every op) by the caller, so a later op overwriting the
-    /// same file simply changes the expectation rather than racing.
-    fallocated: std::collections::BTreeSet<String>,
+    /// Paths whose File content an op mutated in a way the generic
+    /// `size == content` invariant alone does not pin to exact bytes:
+    /// `FsOp::Fallocate` (grow / zero / punch) and the destination of
+    /// `FsOp::CopyFileRange`. Deduplicated. The expected post-reload
+    /// bytes are read from the *final* in-memory tree (after every op)
+    /// by the caller, so a later op overwriting the same file simply
+    /// changes the expectation rather than racing.
+    content_mutated: std::collections::BTreeSet<String>,
 }
 
 /// Apply `ops` to `tree`, silently skipping invalid ones. Returns the
@@ -703,7 +706,7 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
                     // generated `mode` is already restricted to the
                     // three supported flavours.
                     if tree.fallocate(ino, *offset, *length, mode.flag()).is_ok() {
-                        exp.fallocated.insert(path);
+                        exp.content_mutated.insert(path);
                     }
                 }
             }
@@ -747,7 +750,7 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
                 } else {
                     tree.resolve_path(Path::new(path))
                 } {
-                    let _ = tree.set_attr_full(ino, perm.map(u32::from), *uid, *gid);
+                    let _ = tree.set_attr_full(ino, (*perm).map(u32::from), *uid, *gid);
                 }
             }
             FsOp::CopyFileRange {
@@ -760,19 +763,27 @@ fn apply_ops(tree: &mut FileTree, ops: &[FsOp]) -> Expectations {
                 if files.is_empty() {
                     continue;
                 }
-                let src_path = &files[src.index(files.len())];
-                let dst_path = &files[dst.index(files.len())];
+                let src_path = files[src.index(files.len())].clone();
+                let dst_path = files[dst.index(files.len())].clone();
                 let (Some(src_ino), Some(dst_ino)) = (
-                    tree.resolve_path(Path::new(src_path)),
-                    tree.resolve_path(Path::new(dst_path)),
+                    tree.resolve_path(Path::new(&src_path)),
+                    tree.resolve_path(Path::new(&dst_path)),
                 ) else {
                     continue;
                 };
                 // Non-file endpoints (EISDIR/EINVAL) or a copy that
-                // moves nothing (Ok(0)) leave the tree unchanged; the
-                // generic post-reload invariants still cover whatever
-                // bytes did land.
-                let _ = tree.copy_file_range(src_ino, *src_offset, dst_ino, *dst_offset, *len);
+                // moves nothing (Ok(0)) leave the destination
+                // unchanged. When bytes actually land, record the
+                // destination so its content round-trips byte-exact
+                // through save→load — copy_file_range mutates dst
+                // file content exactly like Fallocate does, so it
+                // belongs in the same expectation set.
+                if let Ok(copied) =
+                    tree.copy_file_range(src_ino, *src_offset, dst_ino, *dst_offset, *len)
+                    && copied > 0
+                {
+                    exp.content_mutated.insert(dst_path);
+                }
             }
         }
     }
@@ -1541,15 +1552,16 @@ fn assert_mutation_hardlinks_equivalent(
     Ok(())
 }
 
-/// SPEC: every file an `FsOp::Fallocate` touched round-trips its size
-/// and exact bytes through `save → load`. `expected` holds the final
-/// in-memory contents (after the whole op sequence) keyed by path; a
-/// path absent from the reloaded snapshot is tolerated (a later op
-/// renamed or unlinked it). Sparse/hole structure is intentionally
-/// *not* asserted — only the observable read-back bytes and size, per
-/// issue #433's note that on-disk sparseness need not survive
-/// identically.
-fn assert_fallocate_round_trips(
+/// SPEC: every file whose content a mutation op rewrote
+/// (`FsOp::Fallocate`, or the destination of `FsOp::CopyFileRange`)
+/// round-trips its size and exact bytes through `save → load`.
+/// `expected` holds the final in-memory contents (after the whole op
+/// sequence) keyed by path; a path absent from the reloaded snapshot
+/// is tolerated (a later op renamed or unlinked it). Sparse/hole
+/// structure is intentionally *not* asserted — only the observable
+/// read-back bytes and size, per issue #433's note that on-disk
+/// sparseness need not survive identically.
+fn assert_content_mutations_round_trip(
     snap: &BTreeMap<String, ObservedNode>,
     expected: &BTreeMap<String, Vec<u8>>,
 ) -> Result<(), TestCaseError> {
@@ -1559,19 +1571,19 @@ fn assert_fallocate_round_trips(
         };
         let Observed::File { content } = &obs.kind else {
             return Err(TestCaseError::fail(format!(
-                "fallocate'd path {path} reloaded as a non-file"
+                "content-mutated path {path} reloaded as a non-file"
             )));
         };
         prop_assert_eq!(
             content,
             want,
-            "fallocate'd file {} bytes diverged across save→load",
+            "content-mutated file {} bytes diverged across save→load",
             path
         );
         prop_assert_eq!(
             obs.size,
             want.len() as u64,
-            "fallocate'd file {} attr.size {} mismatches content.len {}",
+            "content-mutated file {} attr.size {} mismatches content.len {}",
             path,
             obs.size,
             want.len()
@@ -1672,20 +1684,21 @@ proptest! {
         let mut tree = archive_io::load(&archive, None).unwrap();
         let exp = apply_ops(&mut tree, &ops);
 
-        // Expected post-reload bytes for every fallocate'd file,
-        // read from the FINAL in-memory tree (after every op) so a
-        // later op that overwrote / truncated the same file simply
-        // updates the expectation. A path may have been renamed
-        // away or unlinked by a later op; only those still present
-        // in-memory carry an expectation, and the assertion further
-        // tolerates a path missing post-reload (a later rename).
-        let mut expected_falloc: BTreeMap<String, Vec<u8>> = BTreeMap::new();
-        for path in &exp.fallocated {
+        // Expected post-reload bytes for every content-mutated file
+        // (Fallocate target / CopyFileRange destination), read from
+        // the FINAL in-memory tree (after every op) so a later op
+        // that overwrote / truncated the same file simply updates the
+        // expectation. A path may have been renamed away or unlinked
+        // by a later op; only those still present in-memory carry an
+        // expectation, and the assertion further tolerates a path
+        // missing post-reload (a later rename).
+        let mut expected_content: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+        for path in &exp.content_mutated {
             if let Some(ino) = tree.resolve_path(Path::new(path))
                 && let Some(node) = tree.get(ino)
                 && let FsContent::File(fc) = &node.content
             {
-                expected_falloc.insert(path.clone(), fc.data().to_vec());
+                expected_content.insert(path.clone(), fc.data().to_vec());
             }
         }
 
@@ -1697,7 +1710,7 @@ proptest! {
         assert_no_orphan_inodes(&after_mutated_save)?;
         assert_file_size_matches_content(&snap_first)?;
         assert_mutation_hardlinks_equivalent(&after_mutated_save, &snap_first, &exp.placed_links)?;
-        assert_fallocate_round_trips(&snap_first, &expected_falloc)?;
+        assert_content_mutations_round_trip(&snap_first, &expected_content)?;
 
         // Idempotence under the mutated state: a second cycle from
         // here must reach the same snapshot. If a mutation produced
@@ -1912,16 +1925,17 @@ proptest! {
         let mut tree = archive_io::load(&archive, input.password.clone()).unwrap();
         let exp = apply_ops(&mut tree, &ops);
 
-        // Expected post-reload bytes for every fallocate'd file, read
-        // from the FINAL in-memory tree (after every op); see the
+        // Expected post-reload bytes for every content-mutated file
+        // (Fallocate target / CopyFileRange destination), read from
+        // the FINAL in-memory tree (after every op); see the
         // plaintext property for the rationale.
-        let mut expected_falloc: BTreeMap<String, Vec<u8>> = BTreeMap::new();
-        for path in &exp.fallocated {
+        let mut expected_content: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+        for path in &exp.content_mutated {
             if let Some(ino) = tree.resolve_path(Path::new(path))
                 && let Some(node) = tree.get(ino)
                 && let FsContent::File(fc) = &node.content
             {
-                expected_falloc.insert(path.clone(), fc.data().to_vec());
+                expected_content.insert(path.clone(), fc.data().to_vec());
             }
         }
 
@@ -1934,7 +1948,7 @@ proptest! {
         assert_no_orphan_inodes(&after_mutated_save)?;
         assert_file_size_matches_content(&snap_first)?;
         assert_mutation_hardlinks_equivalent(&after_mutated_save, &snap_first, &exp.placed_links)?;
-        assert_fallocate_round_trips(&snap_first, &expected_falloc)?;
+        assert_content_mutations_round_trip(&snap_first, &expected_content)?;
 
         // Idempotence under the mutated, re-encrypted state: a second
         // decrypt → re-encrypt → decrypt cycle must reach the same

--- a/src/roundtrip_proptest.rs
+++ b/src/roundtrip_proptest.rs
@@ -1886,6 +1886,63 @@ proptest! {
             }
         }
     }
+
+    /// SPEC: the mutation-sequence invariants hold on the **encrypted**
+    /// path too. The plaintext `plain_mutation_sequence_survives_save_load`
+    /// only exercises `password.is_none()`; an arbitrary `Vec<FsOp>`
+    /// applied to a freshly-decrypted tree, then re-saved (re-encrypted
+    /// with a fresh IV) and reloaded with the same password, must still
+    /// satisfy every generic invariant — directory nlink, no orphans,
+    /// size==content, hardlink equivalence, fallocate round-trip — and
+    /// be idempotent under a second decrypt→mutate-free→re-encrypt
+    /// cycle. Idempotence here is the cipher / Clean-Dirty regression
+    /// guard: a node left `Dirty` by a mutation must re-encrypt on
+    /// save, and a `Clean` node must round-trip its existing ciphertext
+    /// unchanged; either accounted wrong would diverge the second
+    /// snapshot. Argon2id keeps this at the block's small case cap.
+    #[test]
+    fn encrypted_mutation_sequence_survives_save_load(
+        input in arb_test_input_encrypted(),
+        ops in prop::collection::vec(arb_fs_op(), 0..=24),
+    ) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let archive = dir.path().join("mut-enc.pna");
+
+        build_and_save(&archive, &input).unwrap();
+        let mut tree = archive_io::load(&archive, input.password.clone()).unwrap();
+        let exp = apply_ops(&mut tree, &ops);
+
+        // Expected post-reload bytes for every fallocate'd file, read
+        // from the FINAL in-memory tree (after every op); see the
+        // plaintext property for the rationale.
+        let mut expected_falloc: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+        for path in &exp.fallocated {
+            if let Some(ino) = tree.resolve_path(Path::new(path))
+                && let Some(node) = tree.get(ino)
+                && let FsContent::File(fc) = &node.content
+            {
+                expected_falloc.insert(path.clone(), fc.data().to_vec());
+            }
+        }
+
+        archive_io::save(&tree).unwrap();
+
+        let after_mutated_save =
+            archive_io::load(&archive, input.password.clone()).unwrap();
+        let snap_first = snapshot(&after_mutated_save);
+        assert_directory_nlink_posix(&snap_first)?;
+        assert_no_orphan_inodes(&after_mutated_save)?;
+        assert_file_size_matches_content(&snap_first)?;
+        assert_mutation_hardlinks_equivalent(&after_mutated_save, &snap_first, &exp.placed_links)?;
+        assert_fallocate_round_trips(&snap_first, &expected_falloc)?;
+
+        // Idempotence under the mutated, re-encrypted state: a second
+        // decrypt → re-encrypt → decrypt cycle must reach the same
+        // snapshot. `assert_save_is_idempotent` reloads with
+        // `input.password`, so this exercises the encrypted save/load
+        // path end to end.
+        assert_save_is_idempotent(&input, &archive, &snap_first)?;
+    }
 }
 
 // ── Helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two focused commits on one branch (both edit `src/roundtrip_proptest.rs`, so serialized per the #431–433 same-file lesson):

**#458 — three new `FsOp` mutation variants** (`9654d92`):
- `SymlinkCreate` — create a symlink under a live directory parent; `EEXIST` on name collision silently skipped (dangling targets round-trip too).
- `SetAttr` — chmod / chown via `set_attr_full`; `perm`/`uid`/`gid` each applied only when `Some`, covering chmod-only, chown-only, and combined. uid/gid use the same synthetic high ranges as `arb_meta` so byte-identity / idempotence stay host-independent.
- `CopyFileRange` — `copy_file_range` between two live Files (or the same one); non-file endpoints / zero-copy silently skipped.

These reuse the existing generic SPEC properties (size==content, directory nlink, no-orphan, idempotence, byte-identity); symlink content round-trips via the existing `observed()` Symlink path. `rename`/`hardlink`/`fallocate` already exist (#445) and were **not** re-added. Invalid generated ops stay skipped, matching the existing mutation-op style.

**#459 — encrypted mutation-sequence property** (`04a7cbe`):
- Adds `encrypted_mutation_sequence_survives_save_load` to the encrypted `proptest!` block. The mutation sequence was previously gated to plaintext (`password.is_none()`); this exercises an arbitrary `Vec<FsOp>` on a freshly-decrypted tree, re-saves (fresh IV), reloads with the same password, and asserts the same generic invariants plus idempotence. The idempotence check reloads with the password, making it the cipher / Clean-Dirty regression guard (a `Dirty` node must re-encrypt; a `Clean` node must round-trip its ciphertext unchanged, else the second snapshot diverges).

No real round-trip bug surfaced (per the task's STOP-and-report rule for #457-class findings).

Closes #458, Closes #459.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --locked --all-targets --all-features` — 0 findings (zero new; CI has no `-D warnings`)
- [x] `cargo test --locked --release` — 188/188 pass (was 187; +1 new encrypted property)
- [x] `PROPTEST_CASES=10000 plain_mutation_sequence_survives_save_load` — pass (72 s)
- [x] `encrypted_mutation_sequence_survives_save_load` swept at 200 cases — pass (289 s). Full 10000 is infeasible for this Argon2id-bound property (~1.4 s/case ≈ 4 h+); the existing encrypted block is deliberately capped at 8 for the same reason. 200 cases is a substantial time-boxed sweep with zero failures.