### PR TITLE
:white_check_mark: Use --file flag for pna create in test scripts

### DIFF
--- a/scripts/tests/test_fsstress.sh
+++ b/scripts/tests/test_fsstress.sh
@@ -82,7 +82,6 @@ ensure_fsstress() {
 
 create_seed_archive() {
   ( cd "$WORKDIR" && echo "seed" > seed.txt && \
-    "$PNA_BIN" create "$ARCHIVE" --overwrite seed.txt 2>/dev/null || \
     "$PNA_BIN" create --file "$ARCHIVE" --overwrite seed.txt )
   rm -f "$WORKDIR/seed.txt"
 }

--- a/scripts/tests/test_fsx.sh
+++ b/scripts/tests/test_fsx.sh
@@ -86,7 +86,6 @@ ensure_fsx() {
 
 create_seed_archive() {
   ( cd "$WORKDIR" && echo "seed" > seed.txt && \
-    "$PNA_BIN" create "$ARCHIVE" --overwrite seed.txt 2>/dev/null || \
     "$PNA_BIN" create --file "$ARCHIVE" --overwrite seed.txt )
   rm -f "$WORKDIR/seed.txt"
 }

--- a/scripts/tests/test_mount.sh
+++ b/scripts/tests/test_mount.sh
@@ -32,7 +32,7 @@ cleanup() {
 }
 
 run() {
-  ( cd "$PROJECT_ROOT" && $PNA_BIN create "$ARCHIVE" -r src --overwrite $PNA_OPTIONS )
+  ( cd "$PROJECT_ROOT" && $PNA_BIN create --file "$ARCHIVE" -r src --overwrite $PNA_OPTIONS )
   $PNAFS_BIN mount "$ARCHIVE" "$MOUNTPOINT" $PNA_FS_OPTIONS &
   PID="$!"
   while [ ! -e "$MOUNTPOINT/src" ]; do

--- a/scripts/tests/test_mount_readonly.sh
+++ b/scripts/tests/test_mount_readonly.sh
@@ -63,8 +63,7 @@ unmount_wait() {
   echo "original content" > seed.txt
   mkdir seeddir
   echo "nested" > seeddir/inner.txt
-  "$PNA_BIN" create "$ARCHIVE" --overwrite seed.txt seeddir 2>/dev/null ||
-    "$PNA_BIN" create --file "$ARCHIVE" --overwrite seed.txt seeddir
+  "$PNA_BIN" create --file "$ARCHIVE" --overwrite seed.txt seeddir
 )
 rm -rf "$WORKDIR/seed.txt" "$WORKDIR/seeddir"
 

--- a/scripts/tests/test_mount_write.sh
+++ b/scripts/tests/test_mount_write.sh
@@ -39,7 +39,6 @@ unmount_wait() {
 # Create archive with a seed file using a relative path so the entry name
 # inside the archive is just "seed.txt" (not an absolute path).
 (cd "$WORKDIR" && echo "seed" > seed.txt && \
-  "$PNA_BIN" create "$ARCHIVE" --overwrite seed.txt 2>/dev/null || \
   "$PNA_BIN" create --file "$ARCHIVE" --overwrite seed.txt)
 rm -f "$WORKDIR/seed.txt"
 

--- a/scripts/tests/test_mount_write_encrypted.sh
+++ b/scripts/tests/test_mount_write_encrypted.sh
@@ -22,7 +22,6 @@ trap cleanup EXIT
 
 # Create encrypted archive with one file (use relative path for predictable entry name)
 (cd "$WORKDIR" && echo "original" > seed.txt && \
-  "$PNA_BIN" create "$ARCHIVE" --overwrite --password "$PASSWORD" seed.txt 2>/dev/null || \
   "$PNA_BIN" create --file "$ARCHIVE" --overwrite --password "$PASSWORD" seed.txt)
 rm -f "$WORKDIR/seed.txt"
 

--- a/scripts/tests/test_mount_write_strategy.sh
+++ b/scripts/tests/test_mount_write_strategy.sh
@@ -22,7 +22,6 @@ trap cleanup EXIT
 # Create archive with a seed file using a relative path so the entry name
 # inside the archive is just "seed.txt" (not an absolute path).
 (cd "$WORKDIR" && echo "seed" > seed.txt && \
-  "$PNA_BIN" create "$ARCHIVE" --overwrite seed.txt 2>/dev/null || \
   "$PNA_BIN" create --file "$ARCHIVE" --overwrite seed.txt)
 rm -f "$WORKDIR/seed.txt"
 

--- a/scripts/tests/test_pjdfstest.sh
+++ b/scripts/tests/test_pjdfstest.sh
@@ -140,7 +140,6 @@ create_seed_archive() {
   # name is just `seed.txt` (not absolute), matching the convention in the
   # other test scripts.
   (cd "$WORKDIR" && echo "seed" > seed.txt && \
-    "$PNA_BIN" create "$ARCHIVE" --overwrite seed.txt 2>/dev/null || \
     "$PNA_BIN" create --file "$ARCHIVE" --overwrite seed.txt)
   rm -f "$WORKDIR/seed.txt"
 }


### PR DESCRIPTION
## Summary
- pna CLI 0.34.0 dropped the positional `pna create <ARCHIVE>` form and now requires `--file <ARCHIVE>`. `scripts/tests/test_mount.sh:35` used the positional form with no fallback, so it has been blowing up the `rust_doc_test` matrix on every dependabot PR.
- Standardize all eight pna-using test scripts on the `--file` form and drop the `... 2>/dev/null || ... --file ...` fallbacks the other seven scripts carried for the transition. `--file` works on both the old and new pna CLI, so a single form is sufficient and easier to maintain.

## Why
`.github/workflows/test.yml` installs `portable-network-archive` via `baptiste0928/cargo-install` with no version pin, so the runners pick up whatever is latest on crates.io. As soon as 0.34.0 was published, the positional form stopped working and the only script without a fallback (`test_mount.sh`) broke, taking the `rust_doc_test` jobs of #472 (rpassword), #473 (codeql-action), and #474 (log) down with it even though none of those PRs touched anything related. Pinning the CLI version in CI is a separate follow-up, tracked outside this PR.

## Test plan
- [ ] CI: all eight `rust_doc_test` matrix entries are green
- [ ] CI: `posix_conformance`, `fsx`, `fsstress` stay green (no regression)
- [ ] After merging to main, rebase the existing dependabot PRs #472, #473, #474 and confirm their `rust_doc_test` recovers
