### PR TITLE
fix(ci): work around shadow fusermount3 breaking FUSE mounts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y fuse3 libfuse3-dev
+          # Workaround for actions/runner-images#14516: a stray
+          # non-setuid fusermount3 can shadow the real one.
+          sudo rm -f /usr/local/bin/fusermount3
       - name: Install dependencies
         if: startsWith(matrix.os, 'freebsd')
         run: |
@@ -90,6 +93,9 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y fuse3 libfuse3-dev libacl1-dev acl
+          # Workaround for actions/runner-images#14516: a stray
+          # non-setuid fusermount3 can shadow the real one.
+          sudo rm -f /usr/local/bin/fusermount3
           # The harness mounts pnafs with --allow-other so pjdfstest's
           # seteuid()-to-nobody/tests/pjdfstest tests can reach the FS;
           # FUSE rejects --allow-other from non-root users unless
@@ -136,6 +142,9 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y fuse3 libfuse3-dev
+          # Workaround for actions/runner-images#14516: a stray
+          # non-setuid fusermount3 can shadow the real one.
+          sudo rm -f /usr/local/bin/fusermount3
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: target
@@ -183,6 +192,9 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y fuse3 libfuse3-dev
+          # Workaround for actions/runner-images#14516: a stray
+          # non-setuid fusermount3 can shadow the real one.
+          sudo rm -f /usr/local/bin/fusermount3
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: target


### PR DESCRIPTION
## Summary
- Recent Ubuntu runner image builds (observed: `ubuntu24/20260804.265`, `ubuntu22-arm64/20260804.87`) ship a stray, non-setuid `/usr/local/bin/fusermount3` that shadows the real setuid helper in `/usr/bin` (earlier in `PATH`). Any unprivileged FUSE mount then fails with `fusermount3: mount failed: Operation not permitted`.
- Root cause is tracked upstream at actions/runner-images#14516.
- Remove the shadow binary right after installing `fuse3` in every job that actually performs a live FUSE mount (`rust_doc_test`, `posix_conformance`, `fsx`, `fsstress`). `rm -f` is a no-op once GitHub fixes the image, so this is safe to keep long-term and can be reverted once the upstream issue is resolved.
- Jobs that only need `libfuse3-dev` for linking but never mount at runtime (`proptest`, `publish`, `rust-clippy`, `bench`) are left untouched.

## Test plan
- [ ] Confirm this PR's CI passes.
- [ ] Rerun failed jobs (if any) until at least one lands on a `20260804.x`-class runner image, and confirm the mount step now succeeds where it previously failed with `Operation not permitted`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of FUSE-based tests on Ubuntu environments by preventing failures caused by an incompatible system utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->